### PR TITLE
Function names for sidebar tag list collide

### DIFF
--- a/app/views/issues/_tags_sidebar.html.erb
+++ b/app/views/issues/_tags_sidebar.html.erb
@@ -1,6 +1,6 @@
-<% unless sidebar_tags.empty? -%>
+<% unless sidebar_tags_issues.empty? -%>
   <%= stylesheet_link_tag 'jquery.tagit.css', :plugin => 'redmine_tags' %>
   <%= stylesheet_link_tag 'redmine_tags', :plugin => 'redmine_tags' %>
   <h3><%= l(:tags) %></h3>
-  <%= render_sidebar_tags %>
+  <%= render_sidebar_tags_issues %>
 <% end -%>

--- a/app/views/wiki/_tags_sidebar.html.erb
+++ b/app/views/wiki/_tags_sidebar.html.erb
@@ -1,6 +1,6 @@
-<% unless sidebar_tags.empty? -%>
+<% unless sidebar_tags_wiki.empty? -%>
   <%= stylesheet_link_tag 'jquery.tagit.css', :plugin => 'redmine_tags' %>
   <%= stylesheet_link_tag 'redmine_tags', :plugin => 'redmine_tags' %>
   <h3><%= l(:tags) %></h3>
-  <%= render_sidebar_tags %>
+  <%= render_sidebar_tags_wiki %>
 <% end -%>

--- a/lib/redmine_tags/patches/issues_helper_patch.rb
+++ b/lib/redmine_tags/patches/issues_helper_patch.rb
@@ -11,7 +11,7 @@ module RedmineTags
       module InstanceMethods
         include TagsHelper
 
-        def sidebar_tags
+        def sidebar_tags_issues
           unless @sidebar_tags
             @sidebar_tags = []
             if :none != RedmineTags.settings[:issues_sidebar].to_sym
@@ -24,8 +24,8 @@ module RedmineTags
           @sidebar_tags
         end
 
-        def render_sidebar_tags
-          render_tags_list(sidebar_tags, {
+        def render_sidebar_tags_issues
+          render_tags_list(sidebar_tags_issues, {
             :show_count => (RedmineTags.settings[:issues_show_count].to_i == 1),
             :open_only => (RedmineTags.settings[:issues_open_only].to_i == 1),
             :style => RedmineTags.settings[:issues_sidebar].to_sym

--- a/lib/redmine_tags/patches/wiki_helper_patch.rb
+++ b/lib/redmine_tags/patches/wiki_helper_patch.rb
@@ -11,7 +11,7 @@ module RedmineTags
       module InstanceMethods
         include TagsHelper
 
-        def sidebar_tags
+        def sidebar_tags_wiki
           unless @sidebar_tags
             @sidebar_tags = []
             if :none != RedmineTags.settings[:issues_sidebar].to_sym
@@ -24,8 +24,8 @@ module RedmineTags
           @sidebar_tags
         end
 
-        def render_sidebar_tags
-          render_tags_list(sidebar_tags, {
+        def render_sidebar_tags_wiki
+          render_tags_list(sidebar_tags_wiki, {
             :show_count => (RedmineTags.settings[:issues_show_count].to_i == 1),
             :open_only => (RedmineTags.settings[:issues_open_only].to_i == 1),
             :style => RedmineTags.settings[:issues_sidebar].to_sym,


### PR DESCRIPTION
The patch to add tag support for Wiki pages implements the same function names for issues and wiki pages for the sidebar tag list. In my system (redmine 2.1.6, ruby 1.9.3p0), this caused the functions from wiki_sidebar_patch to be called when trying to render the issues page. This meant that no tags were displayed. This patch renames the functions so they no longer collide and the issues tag list is displayed when accessing the issues page.
