### PR TITLE
Fix NoMethodErrors with redmine_contacts (#49)

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -47,7 +47,8 @@ module TagsHelper
   end
 
   def tag_color(tag)
-    "##{Digest::MD5.hexdigest(tag.name)[0..5]}"
+    tag_name = tag.respond_to?(:name) ? tag.name : tag
+    "##{Digest::MD5.hexdigest(tag_name)[0..5]}"
   end
         
   # Renders list of tags


### PR DESCRIPTION
RedmineTags::TagsHelper#tag_color assumes it will be passed a Tag (or,
to be more specific, something which responds to :name). Now, if the
object does not respond to :name, it simply uses the MD5 hexdigest of
the object itself -- meaning that it will work when passed a String.

(yes, this is a little bit of a hack -- but I really can't face solving the underlying problem here, which is detailed in [this rather distastefully named blog post](http://nicksda.apotomo.de/2011/10/rails-misapprehensions-helpers-are-shit/).)
