### PR TITLE
Wrap tags on issue list view

### DIFF
--- a/assets/stylesheets/redmine_tags.css
+++ b/assets/stylesheets/redmine_tags.css
@@ -23,10 +23,10 @@ ul.tags li { margin: .25em 0px; }
 
 div.tags { text-align: center; }
 .tag-label { margin: .25em; }
-.tag-label-color { 
+.tag-label-color {
     border: 1px solid rgba(0, 0, 0, 0.2);
     border-radius: 5px;
-    padding: 2px 4px; 
+    padding: 2px 4px;
     display: inline-block;
     margin: 1px;
     color: white;
@@ -61,4 +61,8 @@ ul.tagit li.tagit-choice:hover, ul.tagit li.tagit-choice.remove {
 
 ul.tagit input[type="text"] {
 	background: transparent;
+}
+
+tr.issue td.tags {
+	white-space: normal;
 }


### PR DESCRIPTION
Hi there, me again.

A feature one of our testers requested.  Part of the problem with having as many tags as we do is our tags column gets very, very wide on the issues view.

![screen shot 2013-08-28 at 00 15 57](https://f.cloud.github.com/assets/825088/1038840/f9ba567e-0f6e-11e3-8799-d9bf964413da.png)

This is because by default redmine's CSS forces each column not to wrap.  Interestingly many columns in redmine overwrite this (the subject, assigned to, relations, category, and any free text columns are all allowed to wrap):

![screen shot 2013-08-28 at 00 19 58](https://f.cloud.github.com/assets/825088/1038845/397d4212-0f6f-11e3-8bae-d0811f8b37b4.png)

This pull request adds that same rule for tags columns.

And this is the final result:

![screen shot 2013-08-28 at 00 16 33](https://f.cloud.github.com/assets/825088/1038848/4bd831ba-0f6f-11e3-9213-c88e583ce9d2.png)

We think this is a lot neater.  I would be more than happy to make this an option if you think it shouldn't be the default behaviour.

Thanks and I look forward to hearing your feedback!

Matt
