### PR TITLE
Rendering sidebar tags only if defined

### DIFF
--- a/app/views/issues/_tags_sidebar.html.erb
+++ b/app/views/issues/_tags_sidebar.html.erb
@@ -1,6 +1,8 @@
-<% unless sidebar_tags.empty? -%>
-  <%= stylesheet_link_tag 'jquery.tagit.css', :plugin => 'redmine_tags' %>
-  <%= stylesheet_link_tag 'redmine_tags', :plugin => 'redmine_tags' %>
-  <h3><%= l(:tags) %></h3>
-  <%= render_sidebar_tags %>
+<% if defined?(sidebar_tags) -%>
+  <% unless sidebar_tags.empty? -%>
+    <%= stylesheet_link_tag 'jquery.tagit.css', :plugin => 'redmine_tags' %>
+    <%= stylesheet_link_tag 'redmine_tags', :plugin => 'redmine_tags' %>
+    <h3><%= l(:tags) %></h3>
+    <%= render_sidebar_tags %>
+  <% end -%>
 <% end -%>


### PR DESCRIPTION
When using redmine_workload, the sidebar is not displayed (HTTP 500) when not defined.
