### PR TITLE
Fix autocomplete feature for PostgreSQL

### DIFF
--- a/lib/redmine_tags/patches/issue_patch.rb
+++ b/lib/redmine_tags/patches/issue_patch.rb
@@ -68,7 +68,12 @@ module RedmineTags
 
           # limit to the tags matching given %name_like%
           if options[:name_like]
-            conditions[0] << "AND #{ActsAsTaggableOn::Tag.table_name}.name LIKE ?"
+            conditions[0] << case self.connection.adapter_name
+            when 'PostgreSQL'
+              "AND #{ActsAsTaggableOn::Tag.table_name}.name ILIKE ?"
+            else
+              "AND #{ActsAsTaggableOn::Tag.table_name}.name LIKE ?"
+            end
             conditions << "%#{options[:name_like].downcase}%"
           end
 


### PR DESCRIPTION
Postgres uses a case-sensitive "LIKE" operator.  The Postgres-specific "ILIKE" needs to be used to make case-insensitive searching for autocomplete work correctly.
