### PR TITLE
Travis + some fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: ruby
+
+services:
+    - mysql
+    - postgresql
+
+rvm:
+    - 2.0.0
+    - 2.1.7
+    - 2.2.3
+
+gemfile:
+    - $REDMINE_PATH/Gemfile
+
+env:
+    - REDMINE_VER=3.0.7 DB=mysql
+    - REDMINE_VER=3.1.3 DB=mysql
+    - REDMINE_VER=3.2.0 DB=mysql
+    - REDMINE_VER=3.0.7 DB=postgresql
+    - REDMINE_VER=3.1.3 DB=postgresql
+    - REDMINE_VER=3.2.0 DB=postgresql
+
+before_install:
+    - export PLUGIN_NAME=redmine_tags
+    - export REDMINE_PATH=$HOME/redmine
+    - svn co http://svn.redmine.org/redmine/tags/$REDMINE_VER $REDMINE_PATH
+    - ln -s $TRAVIS_BUILD_DIR $REDMINE_PATH/plugins/$PLUGIN_NAME
+    - cp config/database-$DB-travis.yml $REDMINE_PATH/config/database.yml
+    - cd $REDMINE_PATH
+
+before_script:
+    - echo "config.active_record.schema_format = :sql" >> config/additional_environment.rb
+    - bundle exec rake db:create db:migrate redmine:plugins:migrate db:structure:dump
+
+script:
+    - bundle exec rake redmine:plugins:test NAME=$PLUGIN_NAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ rvm:
     - 2.2.3
     - jruby
 
+matrix:
+  allow_failures:
+    - rvm: jruby
+
 gemfile:
     - $REDMINE_PATH/Gemfile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
     - 2.0.0
     - 2.1.7
     - 2.2.3
+    - jruby
 
 gemfile:
     - $REDMINE_PATH/Gemfile

--- a/config/database-mysql-travis.yml
+++ b/config/database-mysql-travis.yml
@@ -1,0 +1,6 @@
+# http://about.travis-ci.org/docs/user/database-setup/#MySQL
+test:
+  adapter: mysql2
+  database: redmine
+  username: travis
+  encoding: utf8

--- a/config/database-postgresql-travis.yml
+++ b/config/database-postgresql-travis.yml
@@ -1,0 +1,5 @@
+# http://about.travis-ci.org/docs/user/database-setup/#PostgreSQL
+test:
+  adapter: postgresql
+  database: redmine
+  username: postgres

--- a/init.rb
+++ b/init.rb
@@ -28,7 +28,7 @@ Redmine::Plugin.register :redmine_tags do
   author_url  'http://www.ixti.net/'
 
   # TODO: add Travis and check with multiple redmine versions.
-  requires_redmine version_or_higher: '3.1.0'
+  requires_redmine version_or_higher: '3.0.0'
   requires_acts_as_taggable_on
 
   settings :default => {

--- a/init.rb
+++ b/init.rb
@@ -29,7 +29,6 @@ Redmine::Plugin.register :redmine_tags do
 
   # TODO: add Travis and check with multiple redmine versions.
   requires_redmine version_or_higher: '3.0.0'
-  requires_acts_as_taggable_on
 
   settings :default => {
     :issues_sidebar => 'none',

--- a/init.rb
+++ b/init.rb
@@ -18,7 +18,6 @@
 
 require 'redmine'
 require 'redmine_tags'
-require 'redmine_acts_as_taggable_on/initialize'
 
 Redmine::Plugin.register :redmine_tags do
   name        'Redmine Tags'


### PR DESCRIPTION
You can see the test build here: https://travis-ci.org/sdwolf/redmine_tags/builds/95996806

Checks fail on jruby + postgres + redmine 3.1 / 3.2 due to problems with pg_dump but since everything is ok in MRI I added them to allowed failures.

Also removed some leftover code I forgot in #115.

@ixti to finish up the integration you have to login to https://travis-ci.org/ with github and enable it for this repo.