### PR TITLE
Fix context menu

### DIFF
--- a/app/views/tags/_general.html.erb
+++ b/app/views/tags/_general.html.erb
@@ -1,5 +1,5 @@
 <%
-  @settings = ActionController::Parameters.new if !@settings || @settings.blank?
+  @settings = ActionController::Parameters.new(@settings)
 %>
 
 <p>

--- a/app/views/tags/_manage_tags.html.erb
+++ b/app/views/tags/_manage_tags.html.erb
@@ -14,7 +14,7 @@
     </thead>
     <tbody>
       <% tags.each do |tag| %>
-        <tr id="<%= tag.id %>" class="<%= cycle('odd', 'even') %> hascontextmenu">
+        <tr id="<%= tag.id %>" class="<%= cycle('odd', 'even') %>">
           <td class="checkbox hide-when-print">
             <%= check_box_tag 'ids[]', tag.id, false, id: nil %>
           </td>
@@ -29,7 +29,6 @@
       <% end %>
     </tbody>
   </table>
-  <%= context_menu tags_context_menu_path %>
 <% else %>
   <p class="nodata"><%= l :label_no_data %></p>
 <% end %>

--- a/lib/redmine_tags.rb
+++ b/lib/redmine_tags.rb
@@ -1,5 +1,5 @@
 module RedmineTags
   def self.settings
-    Setting[:plugin_redmine_tags]
+    ActionController::Parameters.new(Setting[:plugin_redmine_tags])
   end
 end


### PR DESCRIPTION
The first commit fixes a problem with the settings hash, forcing it to always have indifferent access. Not sure when the problem started. 
The second commit removes the context menu.

Closes #153.