### PR TITLE
Upgrades ruby and redmine versions on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ rvm:
 matrix:
   allow_failures:
     - rvm: jruby
+    - rvm: 2.4.0
 
 gemfile:
     - $REDMINE_PATH/Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ services:
 
 rvm:
     - 2.1.9
-    - 2.2.5
-    - 2.3.1
+    - 2.2.6
+    - 2.3.3
+    - 2.4.0
     - jruby
 
 matrix:
@@ -19,11 +20,13 @@ gemfile:
 
 env:
     - REDMINE_VER=3.1.7 DB=mysql
-    - REDMINE_VER=3.2.4 DB=mysql
+    - REDMINE_VER=3.2.5 DB=mysql
     - REDMINE_VER=3.3.1 DB=mysql
+    - REDMINE_VER=3.3.2 DB=mysql
     - REDMINE_VER=3.1.7 DB=postgresql
-    - REDMINE_VER=3.2.4 DB=postgresql
+    - REDMINE_VER=3.2.5 DB=postgresql
     - REDMINE_VER=3.3.1 DB=postgresql
+    - REDMINE_VER=3.3.2 DB=postgresql
 
 before_install:
     - export PLUGIN_NAME=redmine_tags


### PR DESCRIPTION
Refs #160

The new redmine version (3.3.2) is tested separately since I encountered
a bug while doing a clean install but was not able to reproduce it
afterwards. Maybe the tests catch it.