### PR TITLE
Tag permissions

### DIFF
--- a/app/views/issues/_tags.html.erb
+++ b/app/views/issues/_tags.html.erb
@@ -1,3 +1,4 @@
+<% if @project.module_enabled?(:tags) %>
 <% unless issue.tag_list.empty? %>
   <div class="tags attribute">
     <div class="label">
@@ -7,4 +8,5 @@
       <%= safe_join(issue.tag_counts.collect {|t| render_tag_link(t, show_count: false, open_only: false) }, RedmineTags.settings[:issues_use_colors].to_i > 0 ? ' ' : ', ') %>
     </div>
   </div>
+<% end %>
 <% end %>

--- a/app/views/issues/_tags_form.html.erb
+++ b/app/views/issues/_tags_form.html.erb
@@ -1,3 +1,4 @@
+<% if @project.module_enabled?(:tags) && User.current.allowed_to?(:issue_edit_tags, @project) %>
 <div class="tabular">
   <p id="issue_tags">
   <% issue = Issue.new project: issues.first.project if defined? issues %>
@@ -31,3 +32,4 @@
     showAutocompleteOnFocus: true,
   });" %>
 </div>
+<% end %>

--- a/app/views/issues/_tags_sidebar.html.erb
+++ b/app/views/issues/_tags_sidebar.html.erb
@@ -1,4 +1,4 @@
-<% if defined?(sidebar_tags) && !sidebar_tags.empty? && !@issue %>
+<% if (defined?(sidebar_tags)) && @project.module_enabled?(:tags) && !sidebar_tags.empty? && !@issue %>
   <%= stylesheet_link_tag 'jquery.tagit.css', plugin: 'redmine_tags' %>
   <%= stylesheet_link_tag 'redmine_tags', plugin: 'redmine_tags' %>
   <h3><%= l :tags %></h3>

--- a/app/views/wiki/_tags.html.erb
+++ b/app/views/wiki/_tags.html.erb
@@ -1,4 +1,6 @@
+<% if @project.module_enabled?(:tags) -%>
 <% unless page.tag_list.empty? %>
   <b><%= l :tags %>:</b>
   <%= safe_join(page.tag_counts.collect{|t| render_tag_link(t, show_count: false, open_only: false) }, RedmineTags.settings[:issues_use_colors].to_i > 0 ? ' ' : ', ') %>
+<% end %>
 <% end %>

--- a/app/views/wiki/_tags_form.html.erb
+++ b/app/views/wiki/_tags_form.html.erb
@@ -1,3 +1,4 @@
+<% if @project.module_enabled?(:tags) && User.current.allowed_to?(:wiki_edit_tags, @project) %>
 <p id="wiki_tags">
   <%= label_tag l(:tags), nil, for: :wiki_page_tag_list %>
   <%= text_field_tag 'wiki_page[tag_list]', page.tag_list.to_s, class: 'hol',
@@ -23,3 +24,4 @@
     caseSensitive: false,
     removeConfirmation: true,
   });" %>
+<% end %>

--- a/app/views/wiki/_tags_sidebar.html.erb
+++ b/app/views/wiki/_tags_sidebar.html.erb
@@ -1,6 +1,8 @@
+<% if @project.module_enabled?(:tags) -%>
 <% unless sidebar_tags.empty? %>
   <%= stylesheet_link_tag 'jquery.tagit.css', plugin: 'redmine_tags' %>
   <%= stylesheet_link_tag 'redmine_tags', plugin: 'redmine_tags' %>
   <h3><%= l :tags %></h3>
   <%= render_sidebar_tags %>
+<% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,3 +26,7 @@ en:
   issue_tags_tag: Tag
   issue_tags_button_merge: Merge
   issue_tags_label_merge: Merge selected tags
+
+  permission_issue_edit_tags: Edit tags for issues
+  permission_wiki_edit_tags: Edit tags for wiki
+  

--- a/db/migrate/20170421205001_enable_for_all_projects_migration.rb
+++ b/db/migrate/20170421205001_enable_for_all_projects_migration.rb
@@ -1,0 +1,24 @@
+class EnableForAllProjectsMigration < ActiveRecord::Migration
+    def up
+        Project.all.each do |p|
+            if p.module_enabled?(:tags)
+                puts "Some projects have Tags already enabled. Not enabling Tags for all projects"
+                return
+            end
+        end
+
+        Project.all.each do |p|
+            enabled_module_names = p.enabled_module_names
+            if !enabled_module_names.include?(:tags)
+                enabled_module_names.push(:tags)
+            end
+
+            p.enabled_module_names = enabled_module_names
+            if p.save
+                puts "Enable Tags for " + p.name
+            else
+                puts "Failed to enable Tags for " + p.name
+            end
+        end
+    end
+end

--- a/init.rb
+++ b/init.rb
@@ -17,6 +17,11 @@ Redmine::Plugin.register :redmine_tags do
 
   requires_redmine version_or_higher: '3.0.0'
 
+  project_module :tags do
+    permission :issue_edit_tags, { }
+    permission :wiki_edit_tags, { }
+  end
+
   settings \
     default:  {
       issues_sidebar:    'none',


### PR DESCRIPTION
PR for #162

Fixes by @minkbear (back ported)
- Edit permissions per role to edit tags on issues
- Edit permissions per role to edit tags on wiki
- Enable Tags per project

Migration script to enable Tags for all projects, to duplicate current behaviour where Tags is enabled by default. Migration script will only enable Tags for all projects if currently Tags is disabled for all projects, so it’s safe to run the migration script multiple times.