### PR TITLE
Contrast color for tag text & Slovak translation

### DIFF
--- a/assets/stylesheets/redmine_tags.css
+++ b/assets/stylesheets/redmine_tags.css
@@ -12,7 +12,7 @@ ul.tags li { margin: .25em 0px; }
 
 table.list tr.issue .tag-label-color a,
 .tags .tag-label-color a,
-.issue .tag-label-color a { color: white; }
+.issue .tag-label-color a { color: inherit; }
 
 tr.issue td.tags {
   text-align: left;

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,0 +1,23 @@
+# Preložil samo.forus@microstep-mis.com
+sk:
+  tags: Tagy
+  field_tags: Tagy
+  field_tag_list: Tagy
+  setting_issue_tags: Tagy úlohy
+  issues_sidebar: Zobraziť tagy v bočnom paneli ako
+  issues_show_count: Počet zobrazených úloh
+  issues_open_only: Zobraziť len otvorené úlohy
+  issues_sort_by: Zoradiť tagy podľa
+  issues_use_colors: Použiť farby
+   
+  issue_tags_sidebar_none: Nezobrazovať
+  issue_tags_sidebar_list: Zoznam
+  issue_tags_sidebar_cloud: Cloud
+  issue_tags_sidebar_simple_cloud: Jednoduchý cloud
+
+  issues_sort_by_name: Názov
+  issues_sort_by_count: Počet úloh
+  issues_sort_order_asc: Vzostupne
+  issues_sort_order_desc: Zostupne
+
+  auto_complete_new_tag: Pridať...

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,4 +1,4 @@
-# Preložil samo.forus@microstep-mis.com
+# Preložili samo.forus@microstep-mis.com a peter.kovac@microstep-mis.com
 sk:
   tags: Tagy
   field_tags: Tagy
@@ -21,3 +21,9 @@ sk:
   issues_sort_order_desc: Zostupne
 
   auto_complete_new_tag: Pridať...
+
+  issue_tags_label_add_tag: + Pridať tag
+  issue_tags_manage_tags: Spravovať tagy
+  issue_tags_tag: Tag
+  issue_tags_button_merge: Zlúčiť
+  issue_tags_label_merge: Zlúčiť vybrané tagy

--- a/test/fixtures/taggings.yml
+++ b/test/fixtures/taggings.yml
@@ -39,3 +39,15 @@ tagging_007:
   taggable_id: 6
   taggable_type: Issue
   context: tags
+
+tagging_008:
+  tag_id: 4
+  taggable_id: 7
+  taggable_type: Issue
+  context: tags
+
+tagging_009:
+  tag_id: 5
+  taggable_id: 7
+  taggable_type: Issue
+  context: tags

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -10,3 +10,6 @@ tag_three:
 tag_four:
   id: 4
   name: Front End
+tag_five:
+  id: 5
+  name: Usability

--- a/test/functional/issues_controller_test.rb
+++ b/test/functional/issues_controller_test.rb
@@ -93,6 +93,24 @@ class IssuesControllerTest < ActionController::TestCase
     assert_select 'input[name=?][value=?]', 'issue[tag_list]', 'Security, Production'
   end
 
+  def test_show_issue_should_display_contrast_tag_colors
+    Setting.plugin_redmine_tags[:issues_use_colors] = '1'
+    @request.session[:user_id] = 1
+    get :show, :id => 7
+    assert_response :success
+
+    assert_select 'div.tags .value' do
+      assert_select 'span.tag-label-color', 2, :text
+      assert_select "span.tag-label-color[style*=?]", "color: white", :text => "Front End"
+      assert_select "span.tag-label-color[style*=?]", "background-color: #f1253f", :text => "Front End"
+      assert_select "span.tag-label-color[style*=?]", "color: black", :text => "Usability"
+      assert_select "span.tag-label-color[style*=?]", "background-color: #16d103", :text => "Usability"
+    end
+
+    assert_select 'input[name=?][value=?]', 'issue[tag_list]', 'Front End, Usability'
+    Setting.plugin_redmine_tags[:issues_use_colors] = '0'
+  end
+
   def test_edit_issue_tags_should_journalize_changes
     @request.session[:user_id] = 1
     put :update, :id => 3, :issue => { :tag_list => 'Security' }


### PR DESCRIPTION
It's hard to read tags with light background colors and white text. This patch uses YIQ method to set text color to black or white, depending on which is the more contrasting to the background color.

The formula for YIQ was taken from [a blog post by Brian Suda](https://24ways.org/2010/calculating-color-contrast/).

Slovak translation file is also included.