### PR TITLE
Fixes wrong logging of tags changes when bulk editing and rubocop update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,21 +1,18 @@
 ## Styles ######################################################################
 
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
 Style/BracesAroundHashParameters:
   Enabled: false
 
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
-
-Style/Encoding:
-  EnforcedStyle: when_needed
 
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
-Style/IndentHash:
+Layout/IndentHash:
   EnforcedStyle: consistent
 
 # New lambda syntax is as ugly to me as new syntax of Hash.
@@ -28,7 +25,7 @@ Style/Lambda:
 #     conn.hset    :k1, now
 #     conn.hincrby :k2, 123
 #   end
-SingleSpaceBeforeFirstArg:
+Layout/SingleSpaceBeforeFirstArg:
   Enabled: false
 
 Style/StringLiterals:

--- a/test/functional/issues_controller_test.rb
+++ b/test/functional/issues_controller_test.rb
@@ -166,4 +166,36 @@ class IssuesControllerTest < ActionController::TestCase
     assert_equal [], Issue.find(4).tag_list
     assert_equal ['Front End'], Issue.find(6).tag_list
   end
+
+  def test_bulk_edit_journal_without_tag_changing
+    # journal should not log tags changing when tags were not changed
+    @request.session[:user_id] = 2
+    post :bulk_update,
+         :ids => [2, 7],
+         :issue => {
+           :new_tag_list => '',
+           :priority_id => 7
+         },
+         :common_tags => ''
+    assert_response 302
+
+    assert_equal ['priority_id'], Issue.find(2).journals.last.details.map(&:prop_key)
+    assert_equal ['priority_id'], Issue.find(7).journals.last.details.map(&:prop_key)
+    assert_equal 7, Issue.find(2).priority_id
+    assert_equal 7, Issue.find(7).priority_id
+  end
+
+  def test_bulk_edit_journal_with_tag_changing
+    # journal should log tags changing when tags were changed
+    @request.session[:user_id] = 2
+    post :bulk_update,
+         :ids => [2, 7],
+         :issue => {
+           :new_tag_list => ['Production', 'Security']
+         }
+    assert_response 302
+
+    assert_equal ['tag_list'], Issue.find(2).journals.last.details.map(&:prop_key)
+    assert_equal ['tag_list'], Issue.find(7).journals.last.details.map(&:prop_key)
+  end
 end


### PR DESCRIPTION
During bulk editing when you change anything else but tags - the history is nevertheless logged with message about tags changing. Examples:
1. you have no tags, bulk edit e.g. priority, do not add tags - in history you see 'tags were deleted'
2. you have same tags, bulk edit e.g. priority, do not change tags - in history you see 'tags were changed from **foo, bar** to **foo, bar**'

2. Latest version of rubocop complained about outdated syntax in the .rubocop.yml