### PR TITLE
Fixed injection point for tags on wiki page

### DIFF
--- a/app/views/wiki/_tags.html.erb
+++ b/app/views/wiki/_tags.html.erb
@@ -1,4 +1,6 @@
 <% unless page.tag_list.empty? %>
-  <b><%= l :tags %>:</b>
-  <%= safe_join(page.tag_counts.collect{|t| render_tag_link(t, show_count: false, open_only: false) }, RedmineTags.settings[:issues_use_colors].to_i > 0 ? ' ' : ', ') %>
+  <div id="wiki-tags">
+    <b><%= l :tags %>:</b>
+    <%= safe_join(page.tag_counts.collect{|t| render_tag_link(t, show_count: false, open_only: false) }, RedmineTags.settings[:issues_use_colors].to_i > 0 ? ' ' : ', ') %>
+  </div>
 <% end %>

--- a/lib/redmine_tags/hooks/views_wiki_hook.rb
+++ b/lib/redmine_tags/hooks/views_wiki_hook.rb
@@ -15,7 +15,7 @@ module RedmineTags
             hook_res.scan(/<script.*<\/script>/m) {|m| scripts += m }
             hook_res.gsub! /<script.*<\/script>/m, ' '
             hook_res.gsub! /\n/, " \\\n"
-            hook_res = javascript_tag "$('.attachments').before('#{ hook_res }')"
+            hook_res = javascript_tag "$('.other-formats').before('#{ hook_res }')"
             hook_res += scripts.html_safe
           elsif action == 'edit'
             hook_res = view_wiki_form_bottom context


### PR DESCRIPTION
Fixed two issues with wiki tags:

1. Injection point for tags block on a wiki page rendered with current Redmine show template lays inside collapsed fieldset, so it's not visible without expanding "Files" block

2. Tags won't render at all if wiki page has no attachment

By the way I embraced tags partial in a div for a structural consistency of a page