### PR TITLE
Getting tags via REST API

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -32,7 +32,7 @@ module TagsHelper
       content << content_tag('span', "(#{ tag.count })", class: 'tag-count')
     end
 
-    style = if use_colors 
+    style = if use_colors
         { class: 'tag-label-color',
           style: tag_style }
       else
@@ -107,6 +107,14 @@ module TagsHelper
       content_tag list_el, content, class: 'tags',
         style: (:simple_cloud == style ? 'text-align: left;' : '')
     end
+  end
+
+  def render_api_redmine_tags(taggable, api)
+    api.array :tags do
+      taggable.tags.each do |tag|
+        api.tag(:id => tag.id, :name => tag.name)
+      end
+    end if include_in_api_response?('tags')
   end
 
   private

--- a/app/views/issues/index_with_tags.api.rsb
+++ b/app/views/issues/index_with_tags.api.rsb
@@ -1,0 +1,3 @@
+render_api_redmine_tags issue, api
+
+api.created_on issue.created_on

--- a/app/views/issues/show_with_tags.api.rsb
+++ b/app/views/issues/show_with_tags.api.rsb
@@ -1,0 +1,3 @@
+render_api_redmine_tags @issue, api
+
+api.created_on @issue.created_on

--- a/app/views/projects/index_with_tags.api.rsb
+++ b/app/views/projects/index_with_tags.api.rsb
@@ -1,0 +1,3 @@
+render_api_redmine_tags(project, api)
+
+api.created_on  project.created_on

--- a/app/views/projects/show_with_tags.api.rsb
+++ b/app/views/projects/show_with_tags.api.rsb
@@ -1,0 +1,3 @@
+render_api_redmine_tags(@project, api)
+
+api.created_on @project.created_on

--- a/lib/redmine_tags/patches/api_template_handler_patch.rb
+++ b/lib/redmine_tags/patches/api_template_handler_patch.rb
@@ -1,0 +1,31 @@
+module RedmineTags
+  module Patches
+    module ApiTemplateHandlerPatch
+      def self.included(base)
+        base.extend(ClassMethods)
+        base.class_eval do
+          class << self
+            alias_method_chain :call, :redmine_tags
+          end
+        end
+      end
+
+      module ClassMethods
+        def call_with_redmine_tags(template)
+          ActionController::Base.view_paths.each do |path|
+            begin
+              lines = File.readlines("#{path}/#{template.virtual_path}_with_tags.api.rsb")
+              template.source.sub!(lines.last, lines.join) unless lines.empty?
+            rescue Errno::ENOENT
+            end
+          end
+          call_without_redmine_tags(template)
+        end
+      end
+    end
+  end
+end
+
+base = Redmine::Views::ApiTemplateHandler
+patch = RedmineTags::Patches::ApiTemplateHandlerPatch
+base.send(:include, patch) unless base.included_modules.include?(patch)

--- a/lib/redmine_tags/patches/project_patch.rb
+++ b/lib/redmine_tags/patches/project_patch.rb
@@ -6,8 +6,8 @@ module RedmineTags
       end
 
       module InstanceMethods
-        def tags
-          Issue.available_tags project: self
+        def tags(options = {})
+          Issue.available_tags options.merge(project: self)
         end
       end
     end

--- a/lib/redmine_tags/patches/project_patch.rb
+++ b/lib/redmine_tags/patches/project_patch.rb
@@ -1,0 +1,19 @@
+module RedmineTags
+  module Patches
+    module ProjectPatch
+      def self.included(base)
+        base.send(:include, InstanceMethods)
+      end
+
+      module InstanceMethods
+        def tags
+          Issue.available_tags project: self
+        end
+      end
+    end
+  end
+end
+
+base = Project
+patch = RedmineTags::Patches::ProjectPatch
+base.send(:include, patch) unless base.included_modules.include?(patch)

--- a/spec/api_template_handler_patch_spec.rb
+++ b/spec/api_template_handler_patch_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe Redmine::Views::ApiTemplateHandler do
+  it 'is patched with RedmineTags::Patches::ApiTemplateHandlerPatch' do
+    patch = RedmineTags::Patches::ApiTemplateHandlerPatch
+    expect(Redmine::Views::ApiTemplateHandler.included_modules).to include(patch)
+  end
+end

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe IssuesController, type: :controller do
+  include LoginSupport
+  include SetupSupport
+  render_views
+
+  context 'using REST API for getting issue tags' do
+    let(:admin)         { create :user, :admin }
+    let(:author)        { create :user }
+    let(:role)          { create :role, :manager }
+    let(:priority)      { create :issue_priority }
+    let(:status_open)   { create :issue_status }
+    let(:status_closed) { create :issue_status, is_closed: true }
+    let(:tracker)       { create :tracker, default_status_id: status_open.id }
+    let(:project_1) do
+      project = create :project
+      project.trackers = [tracker]
+      project.save!
+      member = create(
+        :member,
+        project_id: project.id,
+        role_ids:   [role.id],
+        user_id:    author.id
+      )
+      create :member_role, member_id: member.id, role_id: role.id
+      project
+    end
+    let(:project_2) do
+      project = create :project
+      project.trackers = [tracker]
+      project.save!
+      member = create(
+        :member,
+        project_id: project.id,
+        role_ids:   [role.id],
+        user_id:    author.id
+      )
+      create :member_role, member_id: member.id, role_id: role.id
+      project
+    end
+    let!(:issue_1) { create_issue(project_1, %w{a1 a2}, author, tracker, status_open, priority) }
+    let!(:issue_2) { create_issue(project_2, %w{b3 b4}, author, tracker, status_open, priority) }
+
+    before :example do
+      login_as admin
+    end
+
+    it 'show action should not include tags when not explicitly specified' do
+      get :show, id: issue_1.id, format: :json
+      parsed_response = JSON.parse(response.body)
+      expect(response).to have_http_status(:ok)
+      expect(parsed_response['tags']).to be_nil
+    end
+
+    it 'show action should include tags when requested' do
+      get :show, id: issue_2.id, include: 'tags', format: :json
+      project_response = JSON.parse(response.body)['issue']
+      expect(response).to have_http_status(:ok)
+      expect(project_response['tags']).to_not be_nil
+      expect(project_response['tags'].length).to eq(2)
+    end
+
+    it 'index should not include tags when not explicitly specified' do
+      get :index, format: :json
+      api_response = JSON.parse(response.body)['issues']
+      expect(response).to have_http_status(:ok)
+      expect(api_response).to_not be_nil
+      expect(api_response.length).to eq(2)
+      expect(api_response.first['tags']).to be_nil
+      expect(api_response.last['tags']).to be_nil
+    end
+
+    it 'index should include own tags for each issue' do
+      tags_1 = ActsAsTaggableOn::Tag.where(name: ['a1', 'a2']).collect { |tag| {"id" => tag.id, "name" => tag.name} }
+      tags_2 = ActsAsTaggableOn::Tag.where(name: ['b3', 'b4']).collect { |tag| {"id" => tag.id, "name" => tag.name} }
+      get :index, include: 'tags', format: :json
+      expect(response).to have_http_status(:ok)
+      api_response = JSON.parse(response.body)['issues']
+      expect(api_response).to_not be_nil
+      expect(api_response.length).to eq(2)
+      api_issue_1 = api_response.detect { |i| i["id"] == issue_1.id }
+      api_issue_2 = api_response.detect { |i| i["id"] == issue_2.id }
+      expect(api_issue_1).to_not be_nil
+      expect(api_issue_2).to_not be_nil
+      api_tags_1 = api_issue_1['tags']
+      api_tags_2 = api_issue_2['tags']
+      expect(api_tags_1).to_not be_nil
+      expect(api_tags_1).to match_array(tags_1)
+      expect(api_tags_2).to_not be_nil
+      expect(api_tags_2).to match_array(tags_2)
+    end
+
+  end
+end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe ProjectsController, type: :controller do
+  include LoginSupport
+  include SetupSupport
+  render_views
+
+  context 'using REST API for getting project''s tags' do
+    let(:admin)         { create :user, :admin }
+    let(:author)        { create :user }
+    let(:role)          { create :role, :manager }
+    let(:priority)      { create :issue_priority }
+    let(:status_open)   { create :issue_status }
+    let(:status_closed) { create :issue_status, is_closed: true }
+    let(:tracker)       { create :tracker, default_status_id: status_open.id }
+    let(:project_1) do
+      project = create :project
+      project.trackers = [tracker]
+      project.save!
+      member = create(
+        :member,
+        project_id: project.id,
+        role_ids:   [role.id],
+        user_id:    author.id
+      )
+      create :member_role, member_id: member.id, role_id: role.id
+      project
+    end
+    let(:project_2) do
+      project = create :project
+      project.trackers = [tracker]
+      project.save!
+      member = create(
+        :member,
+        project_id: project.id,
+        role_ids:   [role.id],
+        user_id:    author.id
+      )
+      create :member_role, member_id: member.id, role_id: role.id
+      project
+    end
+
+    before :example do
+      login_as admin
+      create_issue(project_1, %w{a1 a2}, author, tracker, status_open, priority)
+      create_issue(project_1, %w{a2 a3}, author, tracker, status_open, priority)
+      create_issue(project_1, %w{a4 a5}, author, tracker, status_closed, priority)
+      create_issue(project_2, %w{b6 b7}, author, tracker, status_closed, priority)
+      create_issue(project_2, %w{b8 b9}, author, tracker, status_open, priority)
+    end
+
+    it 'show action should not include tags when not explicitly specified' do
+      get :show, id: project_1.id, format: :json
+      parsed_response = JSON.parse(response.body)
+      expect(response).to have_http_status(:ok)
+      expect(parsed_response['tags']).to be_nil
+    end
+
+    it 'show action should include tags when requested' do
+      get :show, id: project_2.id, include: 'tags', format: :json
+      project_response = JSON.parse(response.body)['project']
+      expect(response).to have_http_status(:ok)
+      expect(project_response['tags']).to_not be_nil
+      expect(project_response['tags'].length).to eq(4)
+    end
+
+    it 'index should not include tags when not explicitly specified' do
+      get :index, format: :json
+      api_response = JSON.parse(response.body)['projects']
+      expect(response).to have_http_status(:ok)
+      expect(api_response).to_not be_nil
+      expect(api_response.length).to eq(2)
+      expect(api_response.first['tags']).to be_nil
+      expect(api_response.last['tags']).to be_nil
+    end
+
+    it 'index should include own tags for each project' do
+      tags_1 = ActsAsTaggableOn::Tag.where(name: ['a1', 'a2', 'a3', 'a4', 'a5']).collect { |tag| {"id" => tag.id, "name" => tag.name} }
+      tags_2 = ActsAsTaggableOn::Tag.where(name: ['b6', 'b7', 'b8', 'b9']).collect { |tag| {"id" => tag.id, "name" => tag.name} }
+      get :index, include: 'tags', format: :json
+      expect(response).to have_http_status(:ok)
+      api_response = JSON.parse(response.body)['projects']
+      expect(api_response).to_not be_nil
+      expect(api_response.length).to eq(2)
+      api_project_1 = api_response.detect { |p| p["id"] == project_1.id }
+      api_project_2 = api_response.detect { |p| p["id"] == project_2.id }
+      expect(api_project_1).to_not be_nil
+      expect(api_project_2).to_not be_nil
+      api_tags_1 = api_project_1['tags']
+      api_tags_2 = api_project_2['tags']
+      expect(api_tags_1).to_not be_nil
+      expect(api_tags_1).to match_array(tags_1)
+      expect(api_tags_2).to_not be_nil
+      expect(api_tags_2).to match_array(tags_2)
+    end
+
+  end
+end

--- a/spec/models/project_patch_spec.rb
+++ b/spec/models/project_patch_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+describe Project, type: :model do
+  include SetupSupport
+
+  it 'is patched with RedmineTags::Patches::ProjectPatch' do
+    patch = RedmineTags::Patches::ProjectPatch
+    expect(Project.included_modules).to include(patch)
+  end
+
+  let(:author)        { create :user }
+  let(:role)          { create :role, :manager }
+  let(:priority)      { create :issue_priority }
+  let(:status_open)   { create :issue_status }
+  let(:status_closed) { create :issue_status, is_closed: true }
+  let(:tracker)       { create :tracker, default_status_id: status_open.id }
+  let(:project_1) do
+    project = create :project
+    project.trackers = [tracker]
+    project.save
+    member = create(
+      :member,
+      project_id: project.id,
+      role_ids:   [role.id],
+      user_id:    author.id
+    )
+    create :member_role, member_id: member.id, role_id: role.id
+    project
+  end
+  let(:project_2) do
+    project = create :project
+    project.trackers = [tracker]
+    project.save
+    member = create(
+      :member,
+      project_id: project.id,
+      role_ids:   [role.id],
+      user_id:    author.id
+    )
+    create :member_role, member_id: member.id, role_id: role.id
+    project
+  end
+
+  context '.tags' do
+    before :example do
+      allow(User).to receive(:current).and_return(author)
+    end
+
+    it 'returns an empty relation when no project issues exist' do
+      result = project_1.tags
+      expect(result).to be_an(ActiveRecord::Relation)
+      expect(result).to eq([])
+    end
+
+    it 'returns an empty relation when no project issues have tags' do
+      create_issue(project_1, [], author, tracker, status_open, priority)
+      result = project_1.tags
+      expect(result).to be_an(ActiveRecord::Relation)
+      expect(result.to_a).to eq([])
+    end
+
+    it 'returns one tag when an project issue has one tag' do
+      create_issue(project_1, %w[a], author, tracker, status_open, priority)
+      result_scope = project_1.tags
+      expect(result_scope).to be_an(ActiveRecord::Relation)
+      result = result_scope.to_a
+      expect(result.size).to eq(1)
+      expect(result[0]).to be_an(ActsAsTaggableOn::Tag)
+      expect(result[0].name).to eq('a')
+    end
+
+    it 'returns one tag when many project issues have the same tag' do
+      create_issue(project_1, %w[a], author, tracker, status_open, priority)
+      create_issue(project_1, %w[a], author, tracker, status_open, priority)
+      result_scope = project_1.tags
+      expect(result_scope).to be_an(ActiveRecord::Relation)
+      result = result_scope.to_a
+      expect(result.size).to eq(1)
+      expect(result[0]).to be_an(ActsAsTaggableOn::Tag)
+      expect(result[0].name).to eq('a')
+    end
+
+    it 'returns all tags only once' do
+      create_issue(project_1, %w[a b], author, tracker, status_open, priority)
+      create_issue(project_1, %w[b c], author, tracker, status_open, priority)
+      result_scope = project_1.tags
+      expect(result_scope).to be_an(ActiveRecord::Relation)
+      result = result_scope.to_a
+      expect(result.size).to eq(3)
+      result.each_with_index do |tag, index|
+        expect(tag).to be_an(ActsAsTaggableOn::Tag)
+        expect(%w[a b c]).to include(tag.name)
+      end
+    end
+
+    it 'returns tags for a specific project' do
+      create_issue(project_1, %w[a], author, tracker, status_open, priority)
+      create_issue(project_2, %w[c], author, tracker, status_open, priority)
+      result_scope = project_1.tags
+      expect(result_scope).to be_an(ActiveRecord::Relation)
+      result = result_scope.to_a
+      expect(result.size).to eq(1)
+      expect(result[0]).to be_an(ActsAsTaggableOn::Tag)
+      expect(result[0].name).to eq('a')
+    end
+
+    it 'returns tags regardless of type of status' do
+      create_issue(project_1, %w[a], author, tracker, status_open, priority)
+      create_issue(project_1, %w[b], author, tracker, status_closed, priority)
+      result_scope = project_1.tags
+      expect(result_scope).to be_an(ActiveRecord::Relation)
+      result = result_scope.to_a.uniq
+      expect(result.size).to eq(2)
+      result.each_with_index do |tag, index|
+        expect(tag).to be_an(ActsAsTaggableOn::Tag)
+        expect(%w[a b]).to include(tag.name)
+      end
+    end
+
+    it 'returns tags only for open issues when open_only: true' do
+      create_issue(project_1, %w[a], author, tracker, status_open, priority)
+      create_issue(project_1, %w[b], author, tracker, status_closed, priority)
+      result_scope = project_1.tags(open_only: true)
+      expect(result_scope).to be_an(ActiveRecord::Relation)
+      result = result_scope.to_a
+      expect(result.size).to eq(1)
+      expect(result[0]).to be_an(ActsAsTaggableOn::Tag)
+      expect(result[0].name).to eq('a')
+    end
+
+  end
+end


### PR DESCRIPTION
Implemented the ability of fetching tags for `Issue` and `Project` through `?include=tags` as mentioned in  #127 