### PR TITLE
Fixes MSSQL order by clause being present twice

### DIFF
--- a/app/views/tags/_manage_tags.html.erb
+++ b/app/views/tags/_manage_tags.html.erb
@@ -1,4 +1,4 @@
-<% tags = Issue.available_tags.order(:name) %>
+<% tags = Issue.available_tags %>
 <% unless tags.empty? %>
   <table class="list issues">
     <thead>


### PR DESCRIPTION
Closes #198.
Related to: https://github.com/ixti/redmine_tags/commit/a5f13e080184f72cf915494675afd2f9f235bc92

/cc @marius-balteanu maybe you want to confirm this bug.