### PR TITLE
Since Redmine 4.0 we need at least acts-as-taggable-on version 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
   - postgresql
 
 rvm:
-  - 2.2.10
   - 2.3.8
   - 2.4.5
   - 2.5.3
@@ -14,8 +13,6 @@ matrix:
   allow_failures:
     # Master may fail for any reason, on any ruby version.
     # It's good to keep an eye on it in case if fails because of us.
-    - rvm: 2.2.10
-      env: REDMINE_VER=master DB=mysql
     - rvm: 2.3.8
       env: REDMINE_VER=master DB=mysql
     - rvm: 2.4.5
@@ -32,8 +29,8 @@ matrix:
       env: REDMINE_VER=master DB=postgresql
 
 env:
-  - REDMINE_VER=4.0.0 DB=mysql
-  - REDMINE_VER=4.0.0 DB=postgresql
+  - REDMINE_VER=4.0-stable DB=mysql
+  - REDMINE_VER=4.0-stable DB=postgresql
   - REDMINE_VER=master DB=mysql
   - REDMINE_VER=master DB=postgresql
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-gem 'acts-as-taggable-on'
+gem 'acts-as-taggable-on', '>= 5.0'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Inspired by original `redmine_tags` of Eric Davis.
 
 ## Requirements
 
-- Ruby `>= 2.2.10`
+- Ruby `>= 2.3.8`
 - Redmine `>= 4.0.0`
 
 


### PR DESCRIPTION
I hit same problem with recent Redmine as reported in #206

I believe that it is  benefitial to merge this as more people will be upgrading (and since tags are not yet in core).