### PR TITLE
Set tags when import issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Desktop.ini
 # Application
 .rvmrc
 /tmp
+
+# vsCode
+.vscode

--- a/app/views/imports/_add_issues_fields_mapping.html.erb
+++ b/app/views/imports/_add_issues_fields_mapping.html.erb
@@ -1,0 +1,4 @@
+<p>
+  <label for="import_mapping_tags"><%= l(:field_tags) %></label>
+  <%= mapping_select_tag @import, 'tags' %>
+</p>

--- a/lib/redmine_tags/hooks/views_issues_hook.rb
+++ b/lib/redmine_tags/hooks/views_issues_hook.rb
@@ -6,6 +6,7 @@ module RedmineTags
       render_on :view_issues_sidebar_planning_bottom, partial: 'issues/tags_sidebar'
       render_on :view_issues_bulk_edit_details_bottom, partial: 'issues/bulk_edit_tags'
       render_on :view_layouts_base_html_head, partial: 'tags/header_assets'
+      render_on :view_issues_fields_mapping_bottom, partial: 'imports/add_issues_fields_mapping'
     end
   end
 end

--- a/lib/redmine_tags/patches/issue_import_patch.rb
+++ b/lib/redmine_tags/patches/issue_import_patch.rb
@@ -1,0 +1,31 @@
+module RedmineTags
+  module Patches
+    module IssueImportPatch
+      def self.included(base)
+        base.send(:include, InstanceMethods)
+        base.class_eval do
+          alias_method :extend_object_without_tags, :extend_object
+          alias_method :extend_object, :extend_object_with_tags
+        end
+        IssueImport::AUTO_MAPPABLE_FIELDS.store('tags', 'field_tags')
+      end
+
+      module InstanceMethods
+        def extend_object_with_tags(row, item, issue)
+          extend_object_without_tags(row, item, issue)
+
+          if tags = row_value(row, 'tags')
+            issue.tag_list = tags
+            issue.save_tags
+          end
+
+          issue
+        end
+      end
+    end
+  end
+end
+
+base = IssueImport
+patch = RedmineTags::Patches::IssueImportPatch
+base.send(:include, patch) unless base.included_modules.include?(patch)


### PR DESCRIPTION
Added tag field to issue importer.

If you specify multiple tags, separate them with commas.
![import_csv](https://user-images.githubusercontent.com/28699015/144954826-0eb26ae1-c499-47df-9d51-fcb5721a82fb.png)

It is necessary to change the source of redmine.
https://www.redmine.org/issues/35861
In bottom of
/app/views/imports/_issues_fields_mapping.html.erb
`<%= call_hook(:view_issues_fields_mapping_bottom, :import => @import) %>`
