### PR TITLE
Fix Redmine 5.0 / Rails 6.1 / Zeitwerk

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -17,7 +17,7 @@ class TagsController < ApplicationController
   end
 
   def update
-    @tag.update_attributes(name: params[:tag][:name])
+    @tag.update(name: params[:tag][:name])
     if @tag.save
       flash[:notice] = l :notice_successful_update
       respond_to do |format|

--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'redmine_tags'
+require File.expand_path('lib/redmine_tags', __dir__)
 
 ActiveSupport::Reloader.to_prepare do
   paths = '/lib/redmine_tags/{patches/*_patch,hooks/*_hook}.rb'

--- a/lib/redmine_tags/hooks/model_issue_hook.rb
+++ b/lib/redmine_tags/hooks/model_issue_hook.rb
@@ -9,15 +9,6 @@ module RedmineTags
         bulk_update_tags_to_issues context
       end
 
-      # Issue has an after_save method that calls reload (update_nested_set_attributes)
-      # This makes it impossible for a new record to get a tag_list, it's
-      # cleared on reload. So instead, hook in after the Issue#save to update
-      # this issue's tag_list and call #save ourselves.
-      def controller_issues_new_after_save(context = {})
-        save_tags_to_issue context, false
-        context[:issue].save
-      end
-
       def save_tags_to_issue(context, create_journal)
         params = context[:params]
         issue = context[:issue]

--- a/lib/redmine_tags/patches/api_template_handler_patch.rb
+++ b/lib/redmine_tags/patches/api_template_handler_patch.rb
@@ -12,7 +12,7 @@ module RedmineTags
       end
 
       module ClassMethods
-        def call_with_redmine_tags(template)
+        def call_with_redmine_tags(template, source = nil)
           ActionController::Base.view_paths.each do |path|
             begin
               lines = File.readlines("#{path}/#{template.virtual_path}_with_tags.api.rsb")
@@ -20,7 +20,11 @@ module RedmineTags
             rescue Errno::ENOENT
             end
           end
-          call_without_redmine_tags(template)
+          if source.nil?
+            call_without_redmine_tags(template)
+          else
+            call_without_redmine_tags(template, source)
+          end
         end
       end
     end


### PR DESCRIPTION
1. Make to can load hook with Zeitwerk
2. Replace with update method  
   update_attributes was removed on Rails 6.1.
4. remove controller_issues_new_after_save hook  
   controller_issues_new_after_save raises "ActiveRecord::StaleObjectError Attempted to update a stale object: Issue." in Rails 6.1.  
   This exception can be suppressed by calling reload first, but the existence of this method seems unnecessary.  
   Because it seems that after_save does not call reload from Redmine 4.0.

Regards